### PR TITLE
Add package.yaml to support indexing on haindex.org

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -1,0 +1,18 @@
+name: Emergency alerts from .krisinformation.se
+description: A custom component for emergency information from Swedish authorities
+type: component
+keywords:
+  - krisinformation.de
+  - sweden
+  - swedish
+  - emergency
+  - krisis
+  - crisis
+author:
+  name: Isabella Gross Alström
+  email: isabella.alstrom@gmail.com
+  homepage: https://isabellaalstrom.github.io/
+license: MIT
+files:
+  - custom_components/krisinformation/__init__.py
+  - custom_components/krisinformation/sensor.py

--- a/package.yaml
+++ b/package.yaml
@@ -1,4 +1,4 @@
-name: Emergency alerts from .krisinformation.se
+name: Emergency alerts from krisinformation.se
 description: A custom component for emergency information from Swedish authorities
 type: component
 keywords:


### PR DESCRIPTION
Hey Isabella,

here's my pull request to support indexing of your component on https://haindex.org
Since you didn't provide a license yet, I've been bold and added MIT licensing.

Would be great if you could head over to https://haindex.org, log in with your GitHub account and just paste the link to your repository for indexing: https://github.com/isabellaalstrom/krisinfo-card
The index will then take over and do all the rest.

Thanks, Jens